### PR TITLE
Implement Windows Intel driver versioning scheme

### DIFF
--- a/displayreport_properties.php
+++ b/displayreport_properties.php
@@ -91,7 +91,7 @@
 			}
 			if ($fname == 'driverversionraw') {
 				$fname = 'driverversion';
-				$value = getDriverVerson($value, $row[2], $row[6]);
+				$value = getDriverVerson($value, $row[2], $row[6], $row[11])
 			}
 			if (($fname == 'pipelineCacheUUID') && (!is_null($value))) {
 				$arr = unserialize($value);

--- a/functions.php
+++ b/functions.php
@@ -240,7 +240,7 @@ function reportCompareDeviceColumns($deviceinfo_captions, $deviceinfo_data, $cou
 }
 
 // Convert vendor specific driver version string
-function getDriverVerson($versionraw, $versiontext, $vendorid)
+function getDriverVerson($versionraw, $versiontext, $vendorid, $osname)
 {
 	if ($versionraw != '')
 	{
@@ -252,6 +252,13 @@ function getDriverVerson($versionraw, $versiontext, $vendorid)
 				($versionraw >> 14) & 0x0ff,
 				($versionraw >> 6) & 0x0ff,
 				($versionraw) & 0x003f
+				);
+		}
+		if ($vendorid == 8086 && $osname == 'windows')
+		{
+			return sprintf("%d.%d",
+				($versionraw >> 14),
+				($versionraw) & 0x3fff
 				);
 		}
 		// Use Vulkan version conventions if vendor mapping is not available

--- a/responses/listreports.php
+++ b/responses/listreports.php
@@ -186,7 +186,7 @@
     $devices->execute($params);
     if ($devices->rowCount() > 0) { 
         foreach ($devices as $device) {
-            $driver = getDriverVerson($device["driver"], "", $device["vendorid"]);
+            $driver = getDriverVerson($device["driver"], "", $device["vendorid"], $device["osname"]);
             $data[] = array(
                 'id' => $device["id"], 
                 'devicelimit' => ($limit != '') ? $device["devicelimit"] : null,


### PR DESCRIPTION
These drivers use two component versioning scheme:

	driverVersion = (major << 14) | minor;

This change implementts this in getDriverVerson function.

One more parameter is added ("osname") to distinguish Windows
Intel drivers from other drivers running on Intel HW.