### PR TITLE
Correctly display Imagination Technologies driver versions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -315,6 +315,27 @@ function getDriverVerson($versionraw, $versiontext, $vendorid, $osname)
 				($versionraw) & 0x3fff
 				);
 		}
+		// Imagination Technologies
+		if ($vendorid == 0x1010)
+		{
+			// For production drivers driverVersion is simply a monotonic integer
+			// changeset number that a driver release was built from, with each
+			// subsequent driver release comparing > than the previous.
+			//
+			// The VK_KHR_driver_properties driverInfo field provides more information
+			// such as the major/minor release branch, 1.10, 1.11. etc.
+			//
+			// Non-production builds are automatically given a made up version starting
+			// from 500,000,000 and can be ignored/formatted separately to not clash.
+			if ($versionraw > 500000000)
+			{
+				return sprintf("0.0.%d", $versionraw);
+			}
+			else
+			{
+				return sprintf("%d", $versionraw);
+			}
+		}
 		// Use Vulkan version conventions if vendor mapping is not available
 		return sprintf("%d.%d.%d",
 			($versionraw >> 22),


### PR DESCRIPTION
Hey Sascha,

Just a quick PR that correctly displays the driverVersion field for Imagination Technologies drivers.

Our driverVersion on production drivers is actually just the Perforce changeset # the release was built from, and not a semantic versioning scheme. In practice each major driver release will compare > than previous releases.

We do have one other scenario I've coded up - and that is if someone is running a development driver (this will actually usually be in-house-runs) - in these cases it has a made up changelist number always > 500,000,000 - I've set those to be formatted as 0.0.512123042 - presuming you use the formatted numbers for column sorting, it should make these appear below the genuine production drivers.

The information in VK_KHR_driver_properties' driverInfo is slightly better and shows our major/minor release branch naming as well as the changeset # - something like "1.11@5742315", where driverVersion would just be 5742315 in this case.

Side question - would you be open to being able to use the driverInfo string to help format a better driver version for output? Or perhaps just along side in italics and/or with a tooltip to indicate it is not actually provided by that field itself if you want to keep the actual fields value distinct? Let me know if you're interested, I don't mind contributing a further pull request.

Regards,
Alex