### PR TITLE
Rework compare functionality

### DIFF
--- a/api/internal/comparer.php
+++ b/api/internal/comparer.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ *
+ * Vulkan hardware capability database server implementation
+ *	
+ * Copyright (C) 2016-2022 by Sascha Willems (www.saschawillems.de)
+ *	
+ * This code is free software, you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public
+ * License version 3 as published by the Free Software Foundation.
+ *	
+ * Please review the following information to ensure the GNU Lesser
+ * General Public License version 3 requirements will be met:
+ * http://www.gnu.org/licenses/agpl-3.0.de.html
+ *	
+ * The code is distributed WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU AGPL 3.0 for more details.		
+ *
+ */
+
+ // Writes and reads reports to compare to the server session
+
+session_start();
+header("HTTP/1.1 200 OK");
+$action = $_POST['action'];
+switch($action) {
+    case 'add':
+        if (in_array(intval($_POST['reportid']), $_SESSION['compare_ids']) === false) {
+            $_SESSION['compare_ids'][] = intval($_POST['reportid']);
+            $_SESSION['compare_names'][] = $_POST['reportname'];
+        }
+        break;
+    case 'remove':
+        $deleteIdx = null;
+        for ($i = 0; $i < count($_SESSION['compare_ids']); $i++) {
+            if ($_SESSION['compare_ids'][$i] == intval($_POST['reportid'])) {
+                $deleteIdx = $i;
+                break;
+            }
+        }
+        if ($deleteIdx !== null) {
+            array_splice($_SESSION['compare_ids'], $deleteIdx, 1);
+            array_splice($_SESSION['compare_names'], $deleteIdx, 1);
+        }
+        break;
+    case 'clear':
+        $_SESSION['compare_ids'] = [];
+        $_SESSION['compare_names'] = [];
+        break;
+}
+
+$response = [];
+if (is_array($_SESSION['compare_ids'])) {
+    for ($i = 0; $i < count($_SESSION['compare_ids']); $i++) {
+        $response[] = [
+            "id" => $_SESSION['compare_ids'][$i],
+            "name" => $_SESSION['compare_names'][$i]
+        ];
+    }
+}
+
+$json = json_encode($response);
+echo $json;

--- a/api/internal/comparer.php
+++ b/api/internal/comparer.php
@@ -20,43 +20,37 @@
  *
  */
 
- // Writes and reads reports to compare to the server session
+// Writes and reads reports to compare to the server session
 
 session_start();
 header("HTTP/1.1 200 OK");
+
 $action = $_POST['action'];
+$reportid = intval($_POST['reportid']);
+$reportname = $_POST['reportname'];
+
 switch($action) {
     case 'add':
-        if (in_array(intval($_POST['reportid']), $_SESSION['compare_ids']) === false) {
-            $_SESSION['compare_ids'][] = intval($_POST['reportid']);
-            $_SESSION['compare_names'][] = $_POST['reportname'];
+        if ((!is_array($_SESSION['compare_reports'])) || (!array_key_exists($reportid, $_SESSION['compare_reports']))) {
+            $_SESSION['compare_reports'][$reportid] = $reportname;
         }
         break;
     case 'remove':
-        $deleteIdx = null;
-        for ($i = 0; $i < count($_SESSION['compare_ids']); $i++) {
-            if ($_SESSION['compare_ids'][$i] == intval($_POST['reportid'])) {
-                $deleteIdx = $i;
-                break;
-            }
-        }
-        if ($deleteIdx !== null) {
-            array_splice($_SESSION['compare_ids'], $deleteIdx, 1);
-            array_splice($_SESSION['compare_names'], $deleteIdx, 1);
+        if ((!is_array($_SESSION['compare_reports'])) || (array_key_exists($reportid, $_SESSION['compare_reports']))) {
+            unset($_SESSION['compare_reports'][$reportid]);
         }
         break;
-    case 'clear':
-        $_SESSION['compare_ids'] = [];
-        $_SESSION['compare_names'] = [];
+    case 'clear':      
+        $_SESSION['compare_reports'] = [];
         break;
 }
 
 $response = [];
-if (is_array($_SESSION['compare_ids'])) {
-    for ($i = 0; $i < count($_SESSION['compare_ids']); $i++) {
+if (is_array($_SESSION['compare_reports'])) {
+    foreach ($_SESSION['compare_reports'] as $key => $value) {
         $response[] = [
-            "id" => $_SESSION['compare_ids'][$i],
-            "name" => $_SESSION['compare_names'][$i]
+            "id" => $key,
+            "name" => $value
         ];
     }
 }

--- a/api/internal/devicecomparer.php
+++ b/api/internal/devicecomparer.php
@@ -20,37 +20,37 @@
  *
  */
 
-// Writes and reads reports to compare to the server session
+// Writes and reads devices to compare to the server session
 
 session_start();
 header("HTTP/1.1 200 OK");
 
 $action = $_POST['action'];
-$reportid = intval($_POST['reportid']);
-$reportname = $_POST['reportname'];
+$devicename = $_POST['devicename'];
+$ostype = $_POST['ostype'];
 
 switch($action) {
     case 'add':
-        if ((!is_array($_SESSION['compare_reports'])) || (!array_key_exists($reportid, $_SESSION['compare_reports']))) {
-            $_SESSION['compare_reports'][$reportid] = $reportname;
+        if ((!is_array($_SESSION['compare_devices'])) || (!array_key_exists($devicename, $_SESSION['compare_devices']))) {
+            $_SESSION['compare_devices'][$devicename] = $ostype !== '' ? $ostype : null;
         }
         break;
     case 'remove':
-        if ((!is_array($_SESSION['compare_reports'])) || (array_key_exists($reportid, $_SESSION['compare_reports']))) {
-            unset($_SESSION['compare_reports'][$reportid]);
+        if ((!is_array($_SESSION['compare_devices'])) || (array_key_exists($devicename, $_SESSION['compare_devices']))) {
+            unset($_SESSION['compare_devices'][$devicename]);
         }
         break;
     case 'clear':      
-        $_SESSION['compare_reports'] = [];
+        $_SESSION['compare_devices'] = [];
         break;
 }
 
 $response = [];
-if (is_array($_SESSION['compare_reports'])) {
-    foreach ($_SESSION['compare_reports'] as $key => $value) {
+if (is_array($_SESSION['compare_devices'])) {
+    foreach ($_SESSION['compare_devices'] as $key => $value) {
         $response[] = [
-            "id" => $key,
-            "name" => $value
+            "name" => $key,
+            "ostype" => $value,
         ];
     }
 }

--- a/api/internal/devices.php
+++ b/api/internal/devices.php
@@ -420,7 +420,7 @@ if ($devices->rowCount() > 0) {
             'reportversion' => $device["reportversion"],
             'submissiondate' => $device["submissiondate"],
             'vendor' => $device["vendor"],
-            'compare' => '<center><input type="checkbox" name="devices[]" value="' . $device["device"] . '&os=' . $platform . '"></center>'
+            'compare' => '<center><Button onClick="addToCompare(\''.$device['device'].'\','.($ostype ? $ostype : '').')">Add</Button>',
         );
     }
 }

--- a/api/internal/devices.php
+++ b/api/internal/devices.php
@@ -420,7 +420,7 @@ if ($devices->rowCount() > 0) {
             'reportversion' => $device["reportversion"],
             'submissiondate' => $device["submissiondate"],
             'vendor' => $device["vendor"],
-            'compare' => '<center><Button onClick="addToCompare(\''.$device['device'].'\','.($ostype ? $ostype : '').')">Add</Button>',
+            'compare' => '<center><Button onClick="addToCompare(\''.$device['device'].'\','.($ostype !== null ? $ostype : '').')">Add</Button>',
         );
     }
 }

--- a/api/internal/reportcomparer.php
+++ b/api/internal/reportcomparer.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ *
+ * Vulkan hardware capability database server implementation
+ *	
+ * Copyright (C) 2016-2022 by Sascha Willems (www.saschawillems.de)
+ *	
+ * This code is free software, you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public
+ * License version 3 as published by the Free Software Foundation.
+ *	
+ * Please review the following information to ensure the GNU Lesser
+ * General Public License version 3 requirements will be met:
+ * http://www.gnu.org/licenses/agpl-3.0.de.html
+ *	
+ * The code is distributed WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU AGPL 3.0 for more details.		
+ *
+ */
+
+// Writes and reads reports to compare to the server session
+
+session_start();
+header("HTTP/1.1 200 OK");
+
+$action = $_POST['action'];
+$reportid = intval($_POST['reportid']);
+$reportname = $_POST['reportname'];
+
+switch($action) {
+    case 'add':
+        if ((!is_array($_SESSION['compare_reports'])) || (!array_key_exists($reportid, $_SESSION['compare_reports']))) {
+            $_SESSION['compare_reports'][$reportid] = $reportname;
+        }
+        break;
+    case 'remove':
+        if ((!is_array($_SESSION['compare_reports'])) || (array_key_exists($reportid, $_SESSION['compare_reports']))) {
+            unset($_SESSION['compare_reports'][$reportid]);
+        }
+        break;
+    case 'clear':      
+        $_SESSION['compare_reports'] = [];
+        break;
+}
+
+$response = [];
+if (is_array($_SESSION['compare_reports'])) {
+    foreach ($_SESSION['compare_reports'] as $key => $value) {
+        $response[] = [
+            "id" => $key,
+            "name" => $value
+        ];
+    }
+}        
+$json = json_encode($response);
+echo $json;

--- a/api/internal/reports.php
+++ b/api/internal/reports.php
@@ -275,10 +275,20 @@ $sql = "SELECT
         " . $searchClause . "
         " . $orderBy;
 
+$compareBntFnTemplate = "function compareClick() {
+    var ajaxurl = 'api/internal/comparer.php',
+    data =  {'action': 'add', 'reportid': __reportid__, 'reportname': '__reportname__'};
+    $.post(ajaxurl, data, function (response) {
+        displayCompare(response);
+    });
+    }; compareClick();";
+
 $devices = DB::$connection->prepare($sql . " " . $paging);
 $devices->execute($params);
 if ($devices->rowCount() > 0) {
     foreach ($devices as $device) {
+        $compareBtnJsFn = str_replace('__reportid__', $device['id'], $compareBntFnTemplate);
+        $compareBtnJsFn = str_replace('__reportname__', $device['devicename'], $compareBtnJsFn);
         $driver = getDriverVerson($device["driver"], "", $device["vendorid"], $device["osname"]);
         $data[] = array(
             'id' => $device["id"],
@@ -291,7 +301,8 @@ if ($devices->rowCount() > 0) {
             'osname' => $device["osname"],
             'osversion' => $device["osversion"],
             'osarchitecture' => $device["osarchitecture"],
-            'compare' => '<center><input type="checkbox" name="id[' . $device["id"] . ']"></center>',
+            // @todo
+            'compare' => '<center><Button onClick="'.$compareBtnJsFn.'">Add</Button>',
             'profile' => ($portabilitysubset ? "<center><a href=\"api/v3/getprofile.php?id=".$device["id"]."\">Download</a></center>" : null)
         );
     }

--- a/api/internal/reports.php
+++ b/api/internal/reports.php
@@ -275,20 +275,10 @@ $sql = "SELECT
         " . $searchClause . "
         " . $orderBy;
 
-$compareBntFnTemplate = "function compareClick() {
-    var ajaxurl = 'api/internal/comparer.php',
-    data =  {'action': 'add', 'reportid': __reportid__, 'reportname': '__reportname__'};
-    $.post(ajaxurl, data, function (response) {
-        displayCompare(response);
-    });
-    }; compareClick();";
-
 $devices = DB::$connection->prepare($sql . " " . $paging);
 $devices->execute($params);
 if ($devices->rowCount() > 0) {
     foreach ($devices as $device) {
-        $compareBtnJsFn = str_replace('__reportid__', $device['id'], $compareBntFnTemplate);
-        $compareBtnJsFn = str_replace('__reportname__', $device['devicename'], $compareBtnJsFn);
         $driver = getDriverVerson($device["driver"], "", $device["vendorid"], $device["osname"]);
         $data[] = array(
             'id' => $device["id"],
@@ -301,8 +291,7 @@ if ($devices->rowCount() > 0) {
             'osname' => $device["osname"],
             'osversion' => $device["osversion"],
             'osarchitecture' => $device["osarchitecture"],
-            // @todo
-            'compare' => '<center><Button onClick="'.$compareBtnJsFn.'">Add</Button>',
+            'compare' => '<center><Button onClick="addToCompare('.$device['id'].',\''.$device['devicename'].'\')">Add</Button>',
             'profile' => ($portabilitysubset ? "<center><a href=\"api/v3/getprofile.php?id=".$device["id"]."\">Download</a></center>" : null)
         );
     }

--- a/compare.php
+++ b/compare.php
@@ -65,7 +65,7 @@ if (isset($_REQUEST['reports'])) {
 			$reportids[] = intval($param);
 		}
 	}
-	// @todo: clear session data for this compare?
+	$_SESSION['compare_reports'] = [];
 }
 
 // Compare from device list
@@ -89,7 +89,8 @@ if (isset($_REQUEST['devices'])) {
 		if ($row) {
 			$reportids[] = $row['id'];
 		}
-	}		
+	}
+	$_SESSION['compare_devices'] = [];
 }
 
 // Limit max. number of reports to compare

--- a/js/devicecompare.js
+++ b/js/devicecompare.js
@@ -1,0 +1,78 @@
+/** 		
+ *
+ * OpenCL hardware capability database server implementation
+ *	
+ * Copyright (C) 2021-2022 by Sascha Willems (www.saschawillems.de)
+ *	
+ * This code is free software, you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public
+ * License version 3 as published by the Free Software Foundation.
+ *	
+ * Please review the following information to ensure the GNU Lesser
+ * General Public License version 3 requirements will be met:
+ * http://www.gnu.org/licenses/agpl-3.0.de.html
+ *	
+ * The code is distributed WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU AGPL 3.0 for more details.		
+ *
+ */
+
+var comparerUrl = 'api/internal/devicecomparer.php',
+compareDevices = [];
+
+function clearCompare() {
+    data =  {'action': 'clear' };
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(null);
+    });
+};
+
+function removeFromCompare(name) {
+    data =  {'action': 'remove', 'devicename': name };
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(response);
+    });	
+}
+
+function addToCompare(devicename, ostype) {
+    data = {'action': 'add', 'devicename': devicename, 'ostype': ostype};
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(response);
+    });
+}	
+
+function displayCompare(data) {
+    elem = $('#compare-info');
+    div = $('#compare-div'); 
+    html = '';
+    arr = JSON.parse(data);
+    compareDevices = [];
+    if (Array.isArray(arr)) {
+        html = '';
+        for (var i = 0; i < arr.length; i++) {
+            var element = arr[i];
+            var last = (i == arr.length - 1);
+            var ostypes = ['Windows', 'Linux', 'Android', 'macOS', 'iOS'];
+            var osname = (element.ostype !== null) ? ostypes[element.ostype] : 'All';
+            html += element.name + ' (' + osname + ') <span onClick="removeFromCompare(\'' + element.name + '\');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
+            compareDevices.push(element);
+        }
+    }
+    elem.html(html);
+    compareDevices.length > 0 ? div.show() : div.hide();			
+}
+
+function compare() {
+    var url = 'compare.php?devices[]=';
+    for (var i = 0; i < compareDevices.length; i++) {
+        if (i > 0) {
+            url += '&devices[]=';
+        }
+        var ostypes = ['windows', 'linux', 'android', 'macos', 'ios'];
+        let ostype = compareDevices[i].ostype !== null ? ostypes[compareDevices[i].ostype] : 'all';
+        url += compareDevices[i].name;
+        url += '&os=' + ostype;
+    }
+    location.href = url;
+}

--- a/js/reportcompare.js
+++ b/js/reportcompare.js
@@ -1,0 +1,66 @@
+/** 		
+ *
+ * OpenCL hardware capability database server implementation
+ *	
+ * Copyright (C) 2021-2022 by Sascha Willems (www.saschawillems.de)
+ *	
+ * This code is free software, you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public
+ * License version 3 as published by the Free Software Foundation.
+ *	
+ * Please review the following information to ensure the GNU Lesser
+ * General Public License version 3 requirements will be met:
+ * http://www.gnu.org/licenses/agpl-3.0.de.html
+ *	
+ * The code is distributed WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU AGPL 3.0 for more details.		
+ *
+ */
+
+var comparerUrl = 'api/internal/reportcomparer.php',
+compareIds = [];
+
+function clearCompare() {
+    data =  {'action': 'clear' };
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(null);
+    });
+};
+
+function removeFromCompare(reportid) {
+    data =  {'action': 'remove', 'reportid': reportid };
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(response);
+    });		
+}
+
+function addToCompare(reportid, reportname) {
+    data = {'action': 'add', 'reportid': reportid, 'reportname': reportname};
+    $.post(comparerUrl, data, function (response) {
+        displayCompare(response);
+    });
+}
+
+function displayCompare(data) {
+    elem = $('#compare-info');
+    div = $('#compare-div'); 
+    html = '';
+    arr = JSON.parse(data);
+    compareIds = [];
+    if (Array.isArray(arr)) {
+        html = '';
+        for (var i = 0; i < arr.length; i++) {
+            var element = arr[i];
+            var last = (i == arr.length - 1);
+            html += element.name + ' <span onClick="removeFromCompare(' + element.id + ');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
+            compareIds.push(element.id);
+        }
+    }
+    elem.html(html);
+    compareIds.length > 0 ? div.show() : div.hide();			
+}
+
+function compare() {
+    location.href = 'compare.php?reports=' + compareIds.join();
+}

--- a/listdevices.php
+++ b/listdevices.php
@@ -68,7 +68,7 @@ if ($minApiVersion) {
 	</div>
 
 	<!-- Compare block (only visible when at least one report is selected) -->
-	<div id="compare-div" class="alert alert-info" role="alert" style="text-align: center; display: none;">
+	<div id="compare-div" class="well well-sm" role="alert" style="text-align: center; display: none;">
 		<div class="compare-header">Selected devices for compare:</div>
 		<span id="compare-info"></span>
 		<div class="compare-footer">
@@ -110,66 +110,9 @@ if ($minApiVersion) {
 	</div>
 </center>
 
+<script src="js/devicecompare.js"></script>
+
 <script>
-	var comparerUrl = 'api/internal/devicecomparer.php',
-	compareDevices = [];
-
-	function clearCompare() {
-		data =  {'action': 'clear' };
-		$.post(comparerUrl, data, function (response) {
-			displayCompare(null);
-		});
-    };
-
-	function removeFromCompare(name) {
-    	data =  {'action': 'remove', 'devicename': name };
-    	$.post(comparerUrl, data, function (response) {
-        	displayCompare(response);
-    	});	
-	}
-
-	function addToCompare(devicename, ostype) {
-		data = {'action': 'add', 'devicename': devicename, 'ostype': ostype};
-		$.post(comparerUrl, data, function (response) {
-			displayCompare(response);
-		});
-    }	
-
-	function displayCompare(data) {
-		elem = $('#compare-info');
-		div = $('#compare-div'); 
-		html = '';
-		arr = JSON.parse(data);
-		compareDevices = [];
-		if (Array.isArray(arr)) {
-			html = '';
-			for (var i = 0; i < arr.length; i++) {
-				var element = arr[i];
-				var last = (i == arr.length - 1);
-				var ostypes = ['Windows', 'Linux', 'Android', 'macOS', 'iOS'];
-				var osname = (element.ostype !== null) ? ostypes[element.ostype] : 'All';
-				html += element.name + ' (' + osname + ') <span onClick="removeFromCompare(\'' + element.name + '\');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
-				compareDevices.push(element);
-			}
-		}
-		elem.html(html);
-		compareDevices.length > 0 ? div.show() : div.hide();			
-	}
-
-	function compare() {
-		var url = 'compare.php?devices[]=';
-		for (var i = 0; i < compareDevices.length; i++) {
-			if (i > 0) {
-				url += '&devices[]=';
-			}
-			var ostypes = ['windows', 'linux', 'android', 'macos', 'ios'];
-			let ostype = compareDevices[i].ostype !== null ? ostypes[compareDevices[i].ostype] : 'all';
-			url += compareDevices[i].name;
-			url += '&os=' + ostype;
-		}
-		location.href = url;
-	}
-
 	$(document).on("keypress", "form", function(event) {
 		return event.keyCode != 13;
 	});

--- a/listdevices.php
+++ b/listdevices.php
@@ -157,8 +157,17 @@ if ($minApiVersion) {
 	}
 
 	function compare() {
-		var params = compareDevices.map((element) => (element.name + ':os=' + (element.ostype !== null ? element.ostype : '-1')) ).join();
-		location.href = 'compare.php?devices=' + params;
+		var url = 'compare.php?devices[]=';
+		for (var i = 0; i < compareDevices.length; i++) {
+			if (i > 0) {
+				url += '&devices[]=';
+			}
+			var ostypes = ['windows', 'linux', 'android', 'macos', 'ios'];
+			let ostype = compareDevices[i].ostype !== null ? ostypes[compareDevices[i].ostype] : 'all';
+			url += compareDevices[i].name;
+			url += '&os=' + ostype;
+		}
+		location.href = url;
 	}
 
 	$(document).on("keypress", "form", function(event) {

--- a/listdevices.php
+++ b/listdevices.php
@@ -125,8 +125,15 @@ if ($minApiVersion) {
     	data =  {'action': 'remove', 'devicename': name };
     	$.post(comparerUrl, data, function (response) {
         	displayCompare(response);
-    	});		
+    	});	
 	}
+
+	function addToCompare(devicename, ostype) {
+		data = {'action': 'add', 'devicename': devicename, 'ostype': ostype};
+		$.post(comparerUrl, data, function (response) {
+			displayCompare(response);
+		});
+    }	
 
 	function displayCompare(data) {
 		elem = $('#compare-info');

--- a/listdevices.php
+++ b/listdevices.php
@@ -141,7 +141,7 @@ if ($minApiVersion) {
 				var last = (i == arr.length - 1);
 				var ostypes = ['Windows', 'Linux', 'Android', 'macOS', 'iOS'];
 				var osname = (element.ostype !== null) ? ostypes[element.ostype] : 'All';
-				html += element.name + ' (' + osname + ') <span onClick="removeFromCompare(' + element.name + ');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
+				html += element.name + ' (' + osname + ') <span onClick="removeFromCompare(\'' + element.name + '\');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
 				compareDevices.push(element);
 			}
 		}

--- a/listreports.php
+++ b/listreports.php
@@ -4,7 +4,7 @@
  *
  * Vulkan hardware capability database server implementation
  *	
- * Copyright (C) 2016-2021 by Sascha Willems (www.saschawillems.de)
+ * Copyright (C) 2016-2022 by Sascha Willems (www.saschawillems.de)
  *	
  * This code is free software, you can redistribute it and/or
  * modify it under the terms of the GNU Affero General Public
@@ -128,7 +128,7 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 	</div>
 
 	<!-- Compare block (only visible when at least one report is selected) -->
-	<div id="compare-div" class="alert alert-info" role="alert" style="text-align: center; display: none;">
+	<div id="compare-div" class="well well-sm" role="alert" style="text-align: center; display: none;">
 		<div class="compare-header">Selected reports for compare:</div>
 		<span id="compare-info"></span>
 		<div class="compare-footer">
@@ -175,54 +175,9 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 	</div>
 </center>
 
+<script src="js/reportcompare.js"></script>
+
 <script>
-	var comparerUrl = 'api/internal/reportcomparer.php',
-	compareIds = [];
-
-	function clearCompare() {
-		data =  {'action': 'clear' };
-		$.post(comparerUrl, data, function (response) {
-			displayCompare(null);
-		});
-    };
-
-	function removeFromCompare(reportid) {
-    	data =  {'action': 'remove', 'reportid': reportid };
-    	$.post(comparerUrl, data, function (response) {
-        	displayCompare(response);
-    	});		
-	}
-
-	function addToCompare(reportid, reportname) {
-		data = {'action': 'add', 'reportid': reportid, 'reportname': reportname};
-		$.post(comparerUrl, data, function (response) {
-			displayCompare(response);
-		});
-    }
-
-	function displayCompare(data) {
-		elem = $('#compare-info');
-		div = $('#compare-div'); 
-		html = '';
-		arr = JSON.parse(data);
-		compareIds = [];
-		if (Array.isArray(arr)) {
-			html = '';
-			for (var i = 0; i < arr.length; i++) {
-				var element = arr[i];
-				var last = (i == arr.length - 1);
-				html += element.name + ' <span onClick="removeFromCompare(' + element.id + ');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
-				compareIds.push(element.id);
-			}
-		}
-		elem.html(html);
-		compareIds.length > 0 ? div.show() : div.hide();			
-	}
-
-	function compare() {
-		location.href = 'compare.php?reports=' + compareIds.join();
-	}
-
 	$(document).on("keypress", "form", function(event) {
 		return event.keyCode != 13;
 	});

--- a/listreports.php
+++ b/listreports.php
@@ -127,6 +127,11 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 		</h4>
 	</div>
 
+	<div id="compare-div" class="alert alert-info" role="alert" style="text-align: center; display: none;">
+		<span id="compare-info">No reports selected for compare</span>
+		<Button onClick="clearCompare()">Clear</Button>
+		<Button onClick="compare()">Compare</Button>
+	</div>
 	<?php
 	PageGenerator::platformNavigation('listreports.php', $platform, true, $filter_list->filters);
 	?>
@@ -168,11 +173,53 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 </center>
 
 <script>
+	var ajaxurl = 'api/internal/comparer.php',
+	compareIds = [];
+
+	function clearCompare() {
+		data =  {'action': 'clear' };
+		$.post(ajaxurl, data, function (response) {
+			displayCompare(null);
+		});
+    };
+
+	function removeFromCompare(id) {
+    	data =  {'action': 'remove', 'reportid': id };
+    	$.post(ajaxurl, data, function (response) {
+        	displayCompare(response);
+    	});		
+	}
+
+	function displayCompare(data) {
+		elem = $('#compare-info');
+		div = $('#compare-div'); 
+		html = 'No reports selected for compare';
+		arr = JSON.parse(data);
+		compareIds = [];
+		if (Array.isArray(arr)) {
+			html = 'Selected for compare: ';			
+			arr.map((element) => {
+				html += '<span class="compare-device">' + element.name + ' <Button onClick="removeFromCompare(' + element.id + ');">X</Button></span>'
+				compareIds.push(element.id);
+			});
+		}
+		elem.html(html);
+		compareIds.length > 0 ? div.show() : div.hide();			
+	}
+
+	function compare() {
+		location.href = 'compare.php?reports=' + compareIds.join();
+	}
+
 	$(document).on("keypress", "form", function(event) {
 		return event.keyCode != 13;
 	});
 
 	$(document).ready(function() {
+
+		$.get(ajaxurl, null, function (response) {
+			displayCompare(response);
+		});
 
 		var table = $('#reports').DataTable({
 			"processing": true,

--- a/listreports.php
+++ b/listreports.php
@@ -127,48 +127,52 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 		</h4>
 	</div>
 
+	<!-- Compare block (only visible when at least one report is selected) -->
 	<div id="compare-div" class="alert alert-info" role="alert" style="text-align: center; display: none;">
-		<span id="compare-info">No reports selected for compare</span>
-		<Button onClick="clearCompare()">Clear</Button>
-		<Button onClick="compare()">Compare</Button>
+		<div class="compare-header">Selected reports for compare:</div>
+		<span id="compare-info"></span>
+		<div class="compare-footer">
+			<Button onClick="clearCompare()"><span class='glyphicon glyphicon-button glyphicon-erase'></span> Clear</Button>
+			<Button onClick="compare()"><span class='glyphicon glyphicon-button glyphicon-ok'></span>Compare</Button>
+		</div>
 	</div>
+
 	<?php
 	PageGenerator::platformNavigation('listreports.php', $platform, true, $filter_list->filters);
 	?>
 	<div class='tablediv tab-content' style='display: inline-flex;'>
-		<form method="get" action="compare.php?compare">
-			<table id='reports' class='table table-striped table-bordered table-hover responsive' style='width:auto'>
-				<thead>
-					<tr>
-						<th></th>
-						<?php if (isset($_GET["limit"])) echo "<th></th>" ?>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-						<th></th>
-					</tr>
-					<tr>
-						<th>id</th>
-						<?php if (isset($_GET["limit"])) echo "<th>Limit</th>" ?>
-						<th>Device</th>
-						<th>Driver</th>
-						<th>Api</th>
-						<th>Vendor</th>
-						<th>Type</th>
-						<th>OS</th>
-						<th>Version</th>
-						<th>Platform</th>
-						<th><input type='submit' name='compare' value='compare' class='button'></th>
-					</tr>
-				</thead>
-			</table>
-			<div id="errordiv" style="color:#D8000C;"></div>
-		</form>
+		<table id='reports' class='table table-striped table-bordered table-hover responsive' style='width:auto'>
+			<thead>
+				<tr>
+					<th></th>
+					<?php if (isset($_GET["limit"])) echo "<th></th>" ?>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+				</tr>
+				<tr>
+					<th>id</th>
+					<?php if (isset($_GET["limit"])) echo "<th>Limit</th>" ?>
+					<th>Device</th>
+					<th>Driver</th>
+					<th>Api</th>
+					<th>Vendor</th>
+					<th>Type</th>
+					<th>OS</th>
+					<th>Version</th>
+					<th>Platform</th>
+					<th>Compare</th>
+					<!-- <th><input type='submit' name='compare' value='compare' class='button'></th> -->
+				</tr>
+			</thead>
+		</table>
+		<div id="errordiv" style="color:#D8000C;"></div>
 	</div>
 </center>
 
@@ -197,11 +201,13 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 		arr = JSON.parse(data);
 		compareIds = [];
 		if (Array.isArray(arr)) {
-			html = 'Selected for compare: ';			
-			arr.map((element) => {
-				html += '<span class="compare-device">' + element.name + ' <Button onClick="removeFromCompare(' + element.id + ');">X</Button></span>'
+			html = '';
+			for (var i = 0; i < arr.length; i++) {
+				var element = arr[i];
+				var last = (i == arr.length - 1);
+				html += element.name + ' <span onClick="removeFromCompare(' + element.id + ');" class="glyphicon glyphicon-button glyphicon-trash report-remove-icon"></span> ' + (last ? '' : '- ');
 				compareIds.push(element.id);
-			});
+			}
 		}
 		elem.html(html);
 		compareIds.length > 0 ? div.show() : div.hide();			

--- a/listreports.php
+++ b/listreports.php
@@ -133,7 +133,7 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 		<span id="compare-info"></span>
 		<div class="compare-footer">
 			<Button onClick="clearCompare()"><span class='glyphicon glyphicon-button glyphicon-erase'></span> Clear</Button>
-			<Button onClick="compare()"><span class='glyphicon glyphicon-button glyphicon-ok'></span>Compare</Button>
+			<Button onClick="compare()"><span class='glyphicon glyphicon-button glyphicon-duplicate'></span> Compare</Button>
 		</div>
 	</div>
 

--- a/listreports.php
+++ b/listreports.php
@@ -186,12 +186,19 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 		});
     };
 
-	function removeFromCompare(id) {
-    	data =  {'action': 'remove', 'reportid': id };
+	function removeFromCompare(reportid) {
+    	data =  {'action': 'remove', 'reportid': reportid };
     	$.post(comparerUrl, data, function (response) {
         	displayCompare(response);
     	});		
 	}
+
+	function addToCompare(reportid, reportname) {
+		data = {'action': 'add', 'reportid': reportid, 'reportname': reportname};
+		$.post(comparerUrl, data, function (response) {
+			displayCompare(response);
+		});
+    }
 
 	function displayCompare(data) {
 		elem = $('#compare-info');

--- a/listreports.php
+++ b/listreports.php
@@ -168,7 +168,6 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 					<th>Version</th>
 					<th>Platform</th>
 					<th>Compare</th>
-					<!-- <th><input type='submit' name='compare' value='compare' class='button'></th> -->
 				</tr>
 			</thead>
 		</table>
@@ -177,19 +176,19 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 </center>
 
 <script>
-	var ajaxurl = 'api/internal/comparer.php',
+	var comparerUrl = 'api/internal/reportcomparer.php',
 	compareIds = [];
 
 	function clearCompare() {
 		data =  {'action': 'clear' };
-		$.post(ajaxurl, data, function (response) {
+		$.post(comparerUrl, data, function (response) {
 			displayCompare(null);
 		});
     };
 
 	function removeFromCompare(id) {
     	data =  {'action': 'remove', 'reportid': id };
-    	$.post(ajaxurl, data, function (response) {
+    	$.post(comparerUrl, data, function (response) {
         	displayCompare(response);
     	});		
 	}
@@ -197,7 +196,7 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 	function displayCompare(data) {
 		elem = $('#compare-info');
 		div = $('#compare-div'); 
-		html = 'No reports selected for compare';
+		html = '';
 		arr = JSON.parse(data);
 		compareIds = [];
 		if (Array.isArray(arr)) {
@@ -223,7 +222,7 @@ PageGenerator::header($pageTitle == null ? "Reports" : "Reports for $pageTitle")
 
 	$(document).ready(function() {
 
-		$.get(ajaxurl, null, function (response) {
+		$.get(comparerUrl, null, function (response) {
 			displayCompare(response);
 		});
 

--- a/style.css
+++ b/style.css
@@ -689,3 +689,25 @@ h1 {
 code {
 	background-color: inherit;
 }
+
+.button-glyphicon {
+	height: 20px;
+}
+
+.report-remove-icon {
+	cursor: hand;
+	color: black;
+	/* padding-right: 10px; */
+}
+
+.report-remove-icon:hover {
+	color: #6e0000;
+}
+
+.compare-header {
+	margin-bottom: 10px;
+}
+
+.compare-footer {
+	margin-top: 10px;
+}


### PR DESCRIPTION
This PR overhauls the compare functionality for reports and devices. Currently you can only compare reports and devices that are visible in the current page of the table, making it hard to impossible to filter for a given set of devices.

With the changes in this PR instead of checking devices to compare, one can add every device to a compare list that is persistent across different operating system tabs and is filter changes, making it possible to add the exact devices or reports to the compare that the user is looking for.